### PR TITLE
Changed font loading to HTTPS use

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,8 +18,8 @@
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/hyde.css">
-  <link rel="stylesheet" href='http://fonts.googleapis.com/css?family=Vollkorn' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Roboto:400,300' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" href='https://fonts.googleapis.com/css?family=Vollkorn' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Roboto:400,300' rel='stylesheet' type='text/css'>
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}public/apple-touch-icon-144-precomposed.png">


### PR DESCRIPTION
Latest versions of Chrome (and probably other browsers) block HTTPS websites from loading HTTP resources:
https://support.google.com/chrome/answer/1342714

Google Fonts weren't loading on https://lisacharlotterost.github.io/, this change should fix it.