### PR TITLE
Handle post titles properly in atom feed

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -17,7 +17,7 @@ layout: null
 
  {% for post in site.posts %}
  <entry>
-   <title>{{ post.title }}</title>
+   <title>{{ post.title | xml_escape }}</title>
    <link href="{{ site.url }}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>{{ site.url }}{{ post.id }}</id>


### PR DESCRIPTION
The atom feed (https://lisacharlotterost.github.io/atom.xml) is currently invalid because one of the posts is titled "From Tumblr to Jekyll & GitHub" and the ampersand isn't encoded properly.

This change XML escapes the title which should make the feed valid again.