### PR TITLE
fixed xmlParseEntityRef no name

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -17,7 +17,7 @@ layout: null
 
  {% for post in site.posts %}
  <entry>
-   <title>{{ post.title }}</title>
+   <title>{{ post.title | xml_escape }}</title>
    <link href="{{ site.url }}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>{{ site.url }}{{ post.id }}</id>


### PR DESCRIPTION
This page contains the following errors:
error on line 16 at column 18: xmlParseEntityRef: no name
Below is a rendering of the page up to the first error.